### PR TITLE
Port "Battery Usage Alerts" feature from factory images to aosp

### DIFF
--- a/src/com/android/settings/fuelgauge/PowerUsageFeatureProviderImpl.java
+++ b/src/com/android/settings/fuelgauge/PowerUsageFeatureProviderImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2017 The Android Open Source Project
+ * Copyright (C) 2014-2017 The Dirty Unicorns Project
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.fuelgauge;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.os.Bundle;
+import com.android.settings.fuelgauge.PowerUsageFeatureProvider;
+import java.util.List;
+
+public final class PowerUsageFeatureProviderImpl
+implements PowerUsageFeatureProvider {
+    static final String ADDITIONAL_BATTERY_INFO_ACTION = "com.google.android.apps.turbo.SHOW_ADDITIONAL_BATTERY_INFO";
+    static final String ADDITIONAL_BATTERY_INFO_PACKAGE = "com.google.android.apps.turbo";
+    static final String ADDITIONAL_BATTERY_INFO_ENABLED = "settings:additional_battery_info_enabled";
+    private Context mContext;
+
+    public PowerUsageFeatureProviderImpl(Context context) {
+        mContext = context;
+    }
+
+    public Intent getAdditionalBatteryInfoIntent() {
+        Intent intent = new Intent(ADDITIONAL_BATTERY_INFO_ACTION);
+        return intent.setPackage(ADDITIONAL_BATTERY_INFO_PACKAGE);
+    }
+
+    /*
+     * Enabled force condition propagation
+     * Lifted jumps to return sites
+     */
+    public boolean isAdditionalBatteryInfoEnabled() {
+        Intent intent = getAdditionalBatteryInfoIntent();
+        boolean bl2 = mContext.getPackageManager().queryIntentActivities(intent, 0).isEmpty();
+        if (!bl2) return true;
+        return false;
+    }
+}

--- a/src/com/android/settings/overlay/FeatureFactoryImpl.java
+++ b/src/com/android/settings/overlay/FeatureFactoryImpl.java
@@ -21,6 +21,7 @@ import android.support.annotation.Keep;
 import com.android.settings.dashboard.SuggestionFeatureProvider;
 import com.android.settings.dashboard.SuggestionFeatureProviderImpl;
 import com.android.settings.fuelgauge.PowerUsageFeatureProvider;
+import com.android.settings.fuelgauge.PowerUsageFeatureProviderImpl;
 
 /**
  * {@link FeatureFactory} implementation for AOSP Settings.
@@ -29,6 +30,7 @@ import com.android.settings.fuelgauge.PowerUsageFeatureProvider;
 public class FeatureFactoryImpl extends FeatureFactory {
 
     private SuggestionFeatureProvider mSuggestionFeatureProvider;
+    private PowerUsageFeatureProvider mPowerUsageFeatureProvider;
 
     @Override
     public SupportFeatureProvider getSupportFeatureProvider(Context context) {
@@ -37,7 +39,10 @@ public class FeatureFactoryImpl extends FeatureFactory {
 
     @Override
     public PowerUsageFeatureProvider getPowerUsageFeatureProvider(Context context) {
-        return null;
+        if (mPowerUsageFeatureProvider == null) {
+            mPowerUsageFeatureProvider = new PowerUsageFeatureProviderImpl(context);
+        }
+        return mPowerUsageFeatureProvider;
     }
 
     @Override


### PR DESCRIPTION
Google made the feature available only on official factory images
putting the code in their prebuilt closed source SettingsGoogle.apk

Extracted needed code from smali (thanks @daveyannihilation for
all hints about this) and adpated it to aosp existing code.

NB: this needs the new Turbo.apk in your vendor blobs:
http://gerrit.dirtyunicorns.com/#/c/5497/

Change-Id: I700a7921d6dd35b2f0b8053f51c1d043adb8c7c0