### PR TITLE
Expose Expanded Desktop App Title

### DIFF
--- a/res/layout/expanded_item.xml
+++ b/res/layout/expanded_item.xml
@@ -49,7 +49,7 @@
             android:layout_marginTop="2dip"
             android:singleLine="true"
             android:ellipsize="marquee"
-            android:textColor="@android:color/black"
+            android:textColor="@color/expanded_item_app_title"
             android:textAppearance="@style/TextAppearance.Medium"
             android:textAlignment="viewStart" />
 

--- a/res/values/ex_colors.xml
+++ b/res/values/ex_colors.xml
@@ -19,4 +19,5 @@
     <!-- Expanded desktop -->
     <drawable name="expanded_item_bg_activated">#ffEEEEEE</drawable>
     <drawable name="expanded_item_bg">@android:color/background_light</drawable>
+    <color name="expanded_item_app_title">@android:color/black</color>
 </resources>


### PR DESCRIPTION
Dark themes suffer from visibility issues for app names without this commit