### PR TITLE
ThemeUtils: Cleanup and account for RROs

### DIFF
--- a/src/com/android/settings/display/ThemeUtils.java
+++ b/src/com/android/settings/display/ThemeUtils.java
@@ -26,11 +26,13 @@ import android.os.ServiceManager;
 import android.os.UserHandle;
 
 import java.util.List;
+import java.util.Arrays;
 
 
 public class ThemeUtils {
 
-    private static final String substratumVersionMetadata = "Substratum_Version";
+    private static final String SUBSTRATUM_VERSION_METADATA = "Substratum_Version";
+    private static final String[] WHITELISTED_OVERLAYS = { "android.auto_generated_rro__" };
 
     private static boolean isSubstratumOverlay(
             Context mContext,
@@ -39,7 +41,7 @@ public class ThemeUtils {
             ApplicationInfo appInfo = mContext.getPackageManager().getApplicationInfo(
                     packageName, PackageManager.GET_META_DATA);
             if (appInfo.metaData != null) {
-                int returnMetadata = appInfo.metaData.getInt(substratumVersionMetadata);
+                int returnMetadata = appInfo.metaData.getInt(SUBSTRATUM_VERSION_METADATA);
                 if (String.valueOf(returnMetadata) != null) {
                     return true;
                 }
@@ -54,8 +56,9 @@ public class ThemeUtils {
             OverlayManager mOverlayManager = new OverlayManager();
             List<OverlayInfo> overlayInfoList =
                     mOverlayManager.getOverlayInfosForFramework();
-            for (int i = 0; i < overlayInfoList.size(); i++) {
-                if (isSubstratumOverlay(mContext, overlayInfoList.get(i).packageName))
+            for (OverlayInfo overlay : overlayInfoList) {
+                if (Arrays.asList(WHITELISTED_OVERLAYS).contains(overlay.packageName)) continue;
+                if (isSubstratumOverlay(mContext, overlay.packageName))
                     return true;
             }
         } catch (RemoteException ignored) {


### PR DESCRIPTION
Devices like mata, walleye and taimen ship a android.auto_generated_rro__
overlay in their vendor images, these are not to be disabled
and they don't break UI elements either, so bypass them from our
substratum overlay check.

Change-Id: I1eb9aafd1f170b0c498ad8c9470209bb76a2d0c0
Reported-by: Josh Fox <joshfox87@gmail.com>
Fixes: e2b822dd8944 ("Settings: Disable system theme preferences when Substratum overlays are enabled")
Signed-off-by: Yash Garg <<ben10.yashgarg@gmail.com>>